### PR TITLE
[개발] - 카카오 주소 카테고리 검색 api로 변경

### DIFF
--- a/src/main/java/com/example/searchpharmacyproject/api/dto/DocumentDto.java
+++ b/src/main/java/com/example/searchpharmacyproject/api/dto/DocumentDto.java
@@ -16,6 +16,9 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor
 public class DocumentDto {
 
+    @JsonProperty("place_name")
+    private String placeName;
+
     @JsonProperty("address_name")
     private String addressName;
 
@@ -24,4 +27,7 @@ public class DocumentDto {
 
     @JsonProperty("x")
     private double longitude; //경도
+
+    @JsonProperty("distance")
+    private double distance;
 }

--- a/src/main/java/com/example/searchpharmacyproject/api/service/KakaoCategorySearchService.java
+++ b/src/main/java/com/example/searchpharmacyproject/api/service/KakaoCategorySearchService.java
@@ -1,0 +1,41 @@
+package com.example.searchpharmacyproject.api.service;
+
+import com.example.searchpharmacyproject.api.dto.KakaoApiResponseDto;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpMethod;
+import org.springframework.stereotype.Service;
+import org.springframework.web.client.RestTemplate;
+
+import java.net.URI;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class KakaoCategorySearchService {
+
+    private final KakaoUriBuilderService kakaoUriBuilderService;
+    private final RestTemplate restTemplate;
+
+    private static final String PHARMACY_CATEGORY = "PM9";
+
+    @Value("${kakao.rest.api.key}")
+    private String kakaoRestApiKey;
+
+    public KakaoApiResponseDto requestPharmacyCategorySearch(double latitude, double longitude, double radius) {
+        URI uri = kakaoUriBuilderService.buildUriByCategorySearch(latitude, longitude, radius, PHARMACY_CATEGORY);
+
+        HttpHeaders headers = new HttpHeaders();
+        headers.set(HttpHeaders.AUTHORIZATION, "KakaoAK "+ kakaoRestApiKey);
+        HttpEntity httpEntity = new HttpEntity<>(headers);
+
+        return restTemplate.exchange(uri, HttpMethod.GET, httpEntity, KakaoApiResponseDto.class).getBody();
+    }
+
+
+
+
+}

--- a/src/main/java/com/example/searchpharmacyproject/api/service/KakaoUriBuilderService.java
+++ b/src/main/java/com/example/searchpharmacyproject/api/service/KakaoUriBuilderService.java
@@ -16,6 +16,7 @@ import java.net.URI;
 public class KakaoUriBuilderService {
 
     private static final String KAKAO_LOCAL_SEARCH_ADDRESS_URL = "https://dapi.kakao.com/v2/local/search/address.json";
+    private static final String KAKAO_LOCAL_CATEGORY_SEARCH_URL = "https://dapi.kakao.com/v2/local/search/category.json";
 
     public URI buildUriByAddressSearch(String address) {
         UriComponentsBuilder uriBuilder = UriComponentsBuilder.fromHttpUrl(KAKAO_LOCAL_SEARCH_ADDRESS_URL);
@@ -23,6 +24,23 @@ public class KakaoUriBuilderService {
 
         URI uri = uriBuilder.build().encode().toUri(); //https://dapi.kakao.com/v2/local/search/address.json?query=${address} 가 저장된다.
         log.info("[KakaoUriBuilderService.buildUriByAddressSearch] address: {}, uri: {}", address, uri);
+
+        return uri;
+    }
+
+    public URI buildUriByCategorySearch(double latitude, double longitude, double radius, String category) {
+        double meterRadius = radius * 1000;
+
+        UriComponentsBuilder uriBuilder = UriComponentsBuilder.fromHttpUrl(KAKAO_LOCAL_CATEGORY_SEARCH_URL);
+        uriBuilder.queryParam("category_group_code", category);
+        uriBuilder.queryParam("x", longitude);
+        uriBuilder.queryParam("y", latitude);
+        uriBuilder.queryParam("radius", meterRadius);
+        uriBuilder.queryParam("sort","distance");
+
+        URI uri = uriBuilder.build().encode().toUri();
+
+        log.info("[KakaoUriBuilderService.buildUriByCategorySearch] uri: {}", uri);
 
         return uri;
     }

--- a/src/main/java/com/example/searchpharmacyproject/pharmacy/service/PharmacyRecommendationService.java
+++ b/src/main/java/com/example/searchpharmacyproject/pharmacy/service/PharmacyRecommendationService.java
@@ -34,10 +34,9 @@ public class PharmacyRecommendationService {
         //사용자가 입력한 주소를 dto로 변환해서 가져옴
         DocumentDto documentDto = kakaoApiResponseDto.getDocumentList().get(0);
         //사용자 위치에서 가까운 약국을 리스트로 가져와서 DB에 저장
-        List<Direction> directionList = directionService.buildDirectionList(documentDto);
+        //List<Direction> directionList = directionService.buildDirectionList(documentDto);
+        List<Direction> directionList = directionService.buildDirectionListByCategoryApi(documentDto);
         directionService.saveAll(directionList);
-
-
 
     }
 

--- a/src/test/groovy/com/example/searchpharmacyproject/api/service/KakaoCategorySearchServiceTest.groovy
+++ b/src/test/groovy/com/example/searchpharmacyproject/api/service/KakaoCategorySearchServiceTest.groovy
@@ -1,0 +1,26 @@
+package com.example.searchpharmacyproject.api.service
+
+import com.example.searchpharmacyproject.AbstractIntegrationContainerBaseTest
+import org.springframework.beans.factory.annotation.Autowired
+
+class KakaoCategorySearchServiceTest extends AbstractIntegrationContainerBaseTest {
+
+    @Autowired
+    private KakaoCategorySearchService kakaoCategorySearchService;
+
+    def "위도, 경도, 거리가 주어졌을 때, requestPharmacyCategorySearch 메소드는 정상적으로 document를 반환"() {
+        given:
+        double inputLatitude = 37.85348
+        double inputLongitude = 127.7367
+        double radius = 10.0
+
+        when:
+        def result = kakaoCategorySearchService.requestPharmacyCategorySearch(inputLatitude, inputLongitude, radius)
+
+        then:
+        result.documentList.size() > 0
+        result.metaDto.totalCount > 0
+        println(result.documentList.get(0).placeName + ", 주소 :  " + result.documentList.get(0).addressName);
+        println(result.documentList.get(1).placeName + ", 주소 :  " + result.documentList.get(1).addressName);
+    }
+}


### PR DESCRIPTION
기존에 하버사인 알고리즘을 사용해 주변 약국을 구하는 코드를 작성했으나,

카카오에서 약국(PM9) 이라는 카테고리를 넣으면,
반경 몇 km 이내에 있는 약국을 보여주는 api로 교체했다. 
그에 따른 코드를 변경하고 테스트를 진행했다.